### PR TITLE
Fix GEN and ACC case mapping for the definitive singular neutral article

### DIFF
--- a/src/modern_greek_inflexion/resources/article.py
+++ b/src/modern_greek_inflexion/resources/article.py
@@ -14,8 +14,8 @@ definite_article = {
         },
         NEUT: {
             NOM: {'το'},
-            ACC: {'του'},
-            GEN: {'το'}
+            ACC: {'το'},
+            GEN: {'του'}
         }
     },
     PL: {


### PR DESCRIPTION
According to [Wikitionary](https://en.wiktionary.org/wiki/το), the correct forms are `το` for accusative, and `του` for genitive.